### PR TITLE
Add 'remctl {hostname} puppet agent' command for neptr puppeting

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -22,3 +22,7 @@ mod 'vcsrepo',
 
 mod 'sensu',
   :git => 'https://github.com/sensu/sensu-puppet.git'
+mod 'xinetd',
+  :git => 'https://github.com/puppetlabs/puppetlabs-xinetd.git'
+mod 'remctl',
+  :git => 'https://github.com/NMTCC/puppet-remctl.git'

--- a/site/profiles/manifests/tcc/remctl.pp
+++ b/site/profiles/manifests/tcc/remctl.pp
@@ -1,0 +1,32 @@
+# Class profiles::remctl
+#
+# Configures the remctl commands common to all TCC Fedora client stations
+# Currently, this is 'puppetagent'
+class profiles::tcc::remctl {
+
+  remctl::command { 'puppetagent':
+    commands        => [
+      {
+        'command'    => 'puppet',
+        'subcommand' => 'agent',
+        'executable' => '/usr/local/bin/puppetagent',
+        'acl'        => '/etc/remctl/acl/puppetagent',
+      },
+    ],
+  }
+
+  remctl::acl { 'puppetagent':
+    principals => [
+      'remctl/neptr.nmt.edu@NMT.EDU',
+    ],
+  }
+
+  file { '/usr/local/bin/puppetagent':
+    ensure  => 'file',
+    content => "#!/bin/bash\n/usr/bin/puppet agent --color false $*\n",
+    group   => 'root',
+    mode    => '0750',
+    owner   => 'root',
+  }
+
+}

--- a/site/profiles/manifests/tcc/yum/packages.pp
+++ b/site/profiles/manifests/tcc/yum/packages.pp
@@ -269,7 +269,7 @@ class profiles::tcc::yum::packages {
         'rb_libtorrent',
         'rb_libtorrent-python',
         'redhat-lsb',
-        'remctl',
+#       'remctl',
         'remctl-perl',
         'remctl-python',
         'rssh',

--- a/site/roles/manifests/tcc.pp
+++ b/site/roles/manifests/tcc.pp
@@ -10,6 +10,7 @@ class roles::tcc {
   include profiles::tcc::yum::localizations
   include profiles::tcc::ldap
   include profiles::tcc::passwd
+  include profiles::tcc::remctl
 
   Class[profiles::tcc::yum] -> Class[profiles::tcc::yum::packages] -> Class[profiles::tcc::yum::localizations]
 


### PR DESCRIPTION
Add remctl and xinetd modules to Puppetfile
Create profiles::tcc:remctl, which has remctl::acl and remctl::command for puppetagent, allow only neptr
Remove remctl package from package list, to manage via ::remctl
Add profile to TCC role
