### PR TITLE
Fix password lookups

### DIFF
--- a/site/profiles/manifests/tcc/passwd.pp
+++ b/site/profiles/manifests/tcc/passwd.pp
@@ -5,14 +5,14 @@ class profiles::tcc::passwd {
   user { 'root':
     ensure   => 'present',
     name     => 'root',
-    password => "%{hiera('rootpasswd')}",
+    password => hiera('rootpasswd'),
     system   => true,
   }
 
   user { 'tccgrub':
     ensure   => 'present',
     name     => 'tccgrub',
-    password => "%{hiera('grubpasswd')}",
+    password => hiera('grubpasswd'),
     system   => true,
   }
 


### PR DESCRIPTION
Change lookup to fix the fact that the hashes in /etc/shadow were actually "%{heira('thingpasswd')}", and not the result of the intended heira lookup.
