### PR TITLE
Add NRAO SIW Conference Directories

### DIFF
--- a/site/profiles/manifests/nrao.pp
+++ b/site/profiles/manifests/nrao.pp
@@ -1,0 +1,14 @@
+# class profiles::nrao
+#
+# Defines resources needed for NRAO SIW Conference
+
+class profiles::nrao {
+
+  file { '/var/nrao':
+    ensure => 'directory',
+    owner  => 'demo1',
+    mode   => '0777',
+  }
+
+
+}

--- a/site/roles/manifests/tcc.pp
+++ b/site/roles/manifests/tcc.pp
@@ -12,6 +12,8 @@ class roles::tcc {
   include profiles::tcc::passwd
   include profiles::tcc::remctl
 
+  include profiles::nrao
+
   Class[profiles::tcc::yum] -> Class[profiles::tcc::yum::packages] -> Class[profiles::tcc::yum::localizations]
 
 }


### PR DESCRIPTION
Add /var/nrao owned to the demo1 account for the SIW Conference

From kscott:
We would like a /var/nrao directory created on each Linux machine in
these rooms.  The directory permissions should be 0777 and owned by
the demo1 account.
