### PR TITLE
Add texlive-epstopdf to yum package list

### DIFF
--- a/site/profiles/manifests/tcc/yum/packages.pp
+++ b/site/profiles/manifests/tcc/yum/packages.pp
@@ -304,6 +304,7 @@ class profiles::tcc::yum::packages {
         'tccmotd',
         'tcpdump',
         'tcsh',
+        'texlive-epstopdf',
         'telepathy-glib-debuginfo',
         'telepathy-logger-debuginfo',
         'thunar-volman',


### PR DESCRIPTION
Add the texlive-epstopdf package to package list, this will  also bring
in texlive-epstopdf-bin with the requested epstopdf binary.

From john 20140421124923:
I need the 'epstopdf' utility on the login machines.  This is necessary
because I have a lot of DocBook documents that have LaTeX equations in
them, and the Makefiles build PDFs for the PDF rendering.
