### PR TITLE
Change tcc-reboot cron don't reboot to windows

### DIFF
--- a/site/profiles/files/Fedora/config/19/tcc-reboot
+++ b/site/profiles/files/Fedora/config/19/tcc-reboot
@@ -2,5 +2,5 @@ SHELL=/bin/bash
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
 MAILTO=root
 HOME=/
-15 0 * * * root /usr/local/bin/reboot_to_win 
-45 6 * * * root /usr/local/bin/random_machine_reboot
+#15 0 * * * root /usr/local/bin/reboot_to_win 
+#45 6 * * * root /usr/local/bin/random_machine_reboot


### PR DESCRIPTION
For NRAO SIW Conference the machines need to be in Linux, we will not be
rebooting to windows for the duration.
