### PR TITLE
ReAdd nightly reboots and unlink NRAO profile

### DIFF
--- a/site/profiles/files/Fedora/config/19/tcc-reboot
+++ b/site/profiles/files/Fedora/config/19/tcc-reboot
@@ -2,5 +2,5 @@ SHELL=/bin/bash
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
 MAILTO=root
 HOME=/
-#15 0 * * * root /usr/local/bin/reboot_to_win 
-#45 6 * * * root /usr/local/bin/random_machine_reboot
+15 0 * * * root /usr/local/bin/reboot_to_win 
+45 6 * * * root /usr/local/bin/random_machine_reboot

--- a/site/roles/manifests/tcc.pp
+++ b/site/roles/manifests/tcc.pp
@@ -12,7 +12,6 @@ class roles::tcc {
   include profiles::tcc::passwd
   include profiles::tcc::remctl
 
-  include profiles::nrao
   include profiles::iris
 
   Class[profiles::tcc::yum] -> Class[profiles::tcc::yum::packages] -> Class[profiles::tcc::yum::localizations]


### PR DESCRIPTION
NRAO SIW conference is completed. The NRAO profile has been unlinked
from the TCC role. The nightly reboots have been restored.
