### PR TITLE
Add rsync to iris profile for scripts

### DIFF
--- a/site/profiles/manifests/iris.pp
+++ b/site/profiles/manifests/iris.pp
@@ -23,4 +23,25 @@ class profiles::iris {
   rsync::get { '/etc/profile.d/cwpsu.csh':
     source => 'update.nmt.edu::CWP/cwpsu.csh',
   }
+
+
+  # Rsync IRIS Scripts
+  rsync::get { '/usr/local/sh':
+    path   => '/usr/local/',
+    source => 'update.nmt.edu::IRIS/sh',
+  }
+  rsync::get { '/usr/local/pl':
+    path   => '/usr/local/',
+    source => 'update.nmt.edu::IRIS/pl',
+  }
+
+  #Rsync IRIS Script profiles
+  rsync::get { '/etc/profile.d/iris.sh':
+    source => 'update.nmt.edu::IRIS/iris.sh',
+  }
+  rsync::get { '/etc/profile.d/iris.csh':
+    source => 'update.nmt.edu::IRIS/iris.csh',
+  }
+
+
 }


### PR DESCRIPTION
Add rsync directives to iris profile for IRIS provided scripts in
/usr/local/pl and /usr/local/sh

> > From Juan Lorenzo
> > pl.tgz holds a folder "pl" whcih contains perl scripts
> > I usually have this in a common location:
> > /usr/local/pl

I generated this file with tar -czvf /home/gom/DropBox/pl.tgz
/usr/local/pl

sh.tz holds a few useful bash scripts for killing windows, in
particular, "xk"

I usually keep this at a common location:
/usr/local/sh

Warning: One of my perl scripts is still hard-wired to look for perl
scripts
inside /usr/local/pl

If the final resting place of the perl scripts is different from what I
outlinedabove, let me know so I can make the necessary alterations
later.

cheers,
Juan
