### PR TITLE
Fix troublesome reboot

### DIFF
--- a/site/profiles/manifests/tcc/ldap.pp
+++ b/site/profiles/manifests/tcc/ldap.pp
@@ -45,7 +45,7 @@ class profiles::tcc::ldap(
 
     exec { "ldap-update-cert":
       provider => shell,
-      command =>  "/usr/bin/certutil -A -n itcCA -t 'TCu,TCu,TCu' -i /etc/openldap/cacerts/tccCA.pem -d /etc/openldap/cacerts/; /sbin/reboot",
+      command =>  "/usr/bin/certutil -A -n itcCA -t 'TCu,TCu,TCu' -i /etc/openldap/cacerts/tccCA.pem -d /etc/openldap/cacerts/",
       onlyif => "if [[ -n $(certutil -L -d /etc/openldap/cacerts | grep itcCA) ]]; then exit 1; else exit 0; fi"
     }
   }


### PR DESCRIPTION
A reboot command intended to force a CA cert update proved to be too early in
the puppet manifest, causing some machines to reboot endlessly.
