### PR TITLE
Update PuppetDB config

### DIFF
--- a/site/profiles/manifests/puppet.pp
+++ b/site/profiles/manifests/puppet.pp
@@ -3,7 +3,11 @@
 class profiles::puppet {
   
   class { 'puppetdb': listen_address => '0.0.0.0', }
-  class { 'puppetdb::master::config': restart_puppet => false, }
+  class { 'puppetdb::master::config':
+    restart_puppet  => false,
+    puppetdb_server => 'puppetdb.nmt.edu',
+    puppetdb_port   => 8081,
+  }
 
   cron { "puppet clean reports":
     command => 'cd /var/lib/puppet/reports && find . -type f -name \*.yaml -mtime +7 -print0 | xargs -0 -n50 /bin/rm -f',


### PR DESCRIPTION
The PuppetDB module currently overwrites <s>routes.yaml</s> puppetdb.conf to use the local puppetdb instance, rather than the shared one.
