### PR TITLE
Switch to dhcpcd

### DIFF
--- a/site/profiles/manifests/nmt/config/jessie.pp
+++ b/site/profiles/manifests/nmt/config/jessie.pp
@@ -43,6 +43,9 @@ class profiles::nmt::config::jessie {
     require => File['/etc/lightdm'],
   }
 
+  nofile { '/etc/network/interfaces.d/eth0.nmt', }
+  nofile { '/etc/network/interfaces.d/eth1.nmt', }
+
   configdir { 'profile.d': dest => '/etc', }
   configdir { 'boot': dest => '', }
 
@@ -66,8 +69,6 @@ class profiles::nmt::config::jessie {
   configfile { 'sssd.conf': dest => '/etc/sssd', mode => '0600', }
   configfile { 'sshd_config': dest => '/etc/ssh', }
   configfile { 'lightdm-xsession.desktop': dest => '/usr/share/xsessions', }
-  configfile { 'eth0.nmt': dest => '/etc/network/interfaces.d', }
-  configfile { 'eth1.nmt': dest => '/etc/network/interfaces.d', }
   configfile { 'xinit-compat.desktop': dest => '/usr/share/xsessions', }
   configfile { 'modules': dest => '/etc/initramfs-tools', }
   configfile { 'plymouthd.conf': dest => '/etc/plymouth', }

--- a/site/profiles/manifests/nmt/config/jessie.pp
+++ b/site/profiles/manifests/nmt/config/jessie.pp
@@ -43,8 +43,8 @@ class profiles::nmt::config::jessie {
     require => File['/etc/lightdm'],
   }
 
-  nofile { '/etc/network/interfaces.d/eth0.nmt', }
-  nofile { '/etc/network/interfaces.d/eth1.nmt', }
+  nofile { '/etc/network/interfaces.d/eth0.nmt': }
+  nofile { '/etc/network/interfaces.d/eth1.nmt': }
 
   configdir { 'profile.d': dest => '/etc', }
   configdir { 'boot': dest => '', }

--- a/site/profiles/manifests/nmt/config/jessie.pp
+++ b/site/profiles/manifests/nmt/config/jessie.pp
@@ -120,7 +120,7 @@ class profiles::nmt::config::jessie {
   service { 'clamav-freshclam': ensure => 'stopped', enable => 'false', }
   service { 'spamassassin': ensure => 'stopped', enable => 'false', }
   service { 'ModemManager': ensure => 'stopped', enable => 'false', }
-  service { 'NetworkManager': ensure => 'stopped', enable => 'false', require => Configfile['eth0.nmt'], }
+  service { 'NetworkManager': ensure => 'stopped', enable => 'false', require => Package['dhcpcd5'], }
   service { 'transmission-daemon': enable => 'false', }
   service { 'openvpn': ensure => 'stopped', enable => 'false', }
   service { 'pppd-dns': ensure => 'stopped', enable => 'false', }

--- a/site/profiles/manifests/nmt/packages/jessie.pp
+++ b/site/profiles/manifests/nmt/packages/jessie.pp
@@ -43,6 +43,7 @@ class profiles::nmt::packages::jessie {
     'dconf-editor',
     'debconf-utils',
     'devscripts',
+    'dhcpcd5',
     'dia',
     'dialog',
     'diffutils',


### PR DESCRIPTION
Use dhcpcd instead of dhclient on clients. It works better with Realtek 8168 chips as found on some of our seats. To do this I pulled the dhcpcd package from Sid, modified it to support systemd, rebuilt for Jessie, and put it in the NMT repository. As shipped, dhcpcd5 only has an init script, so systemd did not know it wanted `network.target`.